### PR TITLE
Feature/cache eviction mechanism v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "types": "dist-types/index.d.ts",
   "sideEffects": false,
   "exports": {
+    "types": "./dist-types/index.d.ts",
     "import": "./dist-esm/index.js",
-    "require": "./dist-cjs/index.js",
-    "types": "./dist-types/index.d.ts"
+    "require": "./dist-cjs/index.js"
   },
   "scripts": {
     "build:es": "node ./esbuild.es.js",

--- a/src/PromiseCacheX.ts
+++ b/src/PromiseCacheX.ts
@@ -180,7 +180,7 @@ export class PromiseCacheX<T = unknown> {
       this._evictIfNeeded();
     } else {
       // Delete existing key so re-insert moves it to end (most recently used)
-      this.cache.delete(key);
+      this._delete(key);
     }
 
     this.cache.set(key, {

--- a/src/PromiseCacheX.ts
+++ b/src/PromiseCacheX.ts
@@ -173,10 +173,14 @@ export class PromiseCacheX<T = unknown> {
         : now + (options?.ttl || this.ttl);
 
     const isPromise = value instanceof Promise;
+    const isNewKey = !this.cache.has(key);
 
-    // Evict before inserting if key doesn't exist and we're at capacity
-    if (!this.cache.has(key)) {
+    if (isNewKey) {
+      // Evict before inserting if we're at capacity
       this._evictIfNeeded();
+    } else {
+      // Delete existing key so re-insert moves it to end (most recently used)
+      this.cache.delete(key);
     }
 
     this.cache.set(key, {

--- a/src/PromiseCacheX.unit.test.ts
+++ b/src/PromiseCacheX.unit.test.ts
@@ -428,6 +428,26 @@ describe("PromiseCacheX", () => {
       expect(await lruCache.get("key1", "fallback")).toBe("updated-value1");
     });
 
+    it("should update LRU position when set() is called on existing key", async () => {
+      const lruCache = new PromiseCacheX({ ttl: 5000, maxEntries: 3 });
+
+      await lruCache.get("key1", "value1");
+      await lruCache.get("key2", "value2");
+      await lruCache.get("key3", "value3");
+
+      // Update key1 via set() - should move it to most recently used
+      lruCache.set("key1", "updated-value1");
+
+      // Adding key4 should evict key2 (now the LRU), not key1
+      await lruCache.get("key4", "value4");
+
+      expect(lruCache.size()).toBe(3);
+      expect(lruCache.has("key1")).toBe(true); // Updated, so moved to end
+      expect(lruCache.has("key2")).toBe(false); // LRU, evicted
+      expect(lruCache.has("key3")).toBe(true);
+      expect(lruCache.has("key4")).toBe(true);
+    });
+
     it("should work correctly with TTL expiration", async () => {
       const lruCache = new PromiseCacheX({
         ttl: 1000,


### PR DESCRIPTION
 ---
  Summary

  - Adds LRU (Least Recently Used) cache eviction mechanism with configurable maxEntries limit
  - Protects pending (unresolved) promises from eviction to prevent data loss
  - Introduces helper methods getMaxEntries() and isAtCapacity() for cache introspection
  - Optimized with O(1) eviction using Map insertion order

  Description

  This PR implements an optional size-bounded cache with intelligent eviction. When maxEntries is configured, the cache automatically evicts the least recently used resolved entries when capacity is reached.

  Key Features

  | Feature                    | Behavior                                                         |
  |----------------------------|------------------------------------------------------------------|
  | LRU Eviction               | Removes least recently used item when at capacity                |
  | Pending Promise Protection | Unresolved promises are never evicted (prevents race conditions) |
  | O(1) Access Tracking       | Cache hits move item to end of Map (most recently used position) |
  | Backward Compatible        | No changes required if maxEntries is not set                     |

  Usage

  const cache = new PromiseCacheX({
    ttl: 5000,
    maxEntries: 100  // Cache limited to 100 entries
  });

  Implementation Details

  - Uses Map insertion order to track recency (no extra memory overhead)
  - _moveToEnd(key, item) reorders on cache hit via delete + set
  - _findLRUCandidate() returns first resolved item in O(1) typical case
  - Eviction occurs before inserting new keys (not when updating existing)
  - Promise resolution tracked via .then() to mark items as evictable

  Benchmark Results

  | Test                                  | Throughput  |
  |---------------------------------------|-------------|
  | LRU Eviction (10k inserts, max 1,000) | 102 ops/s   |
  | LRU Eviction (10k inserts, max 100)   | 171 ops/s   |
  | LRU Cache Hits with Reordering        | 1,815 ops/s |

  Test plan

  - Evicts least recently used item when capacity reached
  - Recently accessed items are preserved (LRU ordering works)
  - Pending promises protected from eviction
  - Resolved promises become evictable
  - Unbounded cache behavior unchanged (backward compatibility)
  - getMaxEntries() and isAtCapacity() return correct values
  - Edge case: all items pending (cannot evict, cache grows)